### PR TITLE
parser周りをリファクタリング

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,16 +37,7 @@ func main() {
 
 	ctx := context.Background()
 	txtAdapter := adapter.NewTxtAdapter(txtAdConn)
-	parser := parser.NewParser(parser.ParseConfig{
-		Signal: parser.Signal{
-			SumBytes:          1604,
-			SumCheckCodeSize:  4,
-			NumPoints:         50,
-			NumChannels:       16,
-			IndexAvailableChs: []int{0, 1, 2, 3, 4, 5, 6, 7},
-			IndexPntsSumCheck: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-		},
-	})
+	parser := parser.NewParser()
 	binAdapter := adapter.NewBinAdapter(binAdConn, parser)
 
 	err = txtAdapter.StartRec(ctx, time.Second*60, time.Now())

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,8 +38,14 @@ func main() {
 	ctx := context.Background()
 	txtAdapter := adapter.NewTxtAdapter(txtAdConn)
 	parser := parser.NewParser(parser.ParseConfig{
-		SumBytes:         1604,
-		SumCheckCodeSize: 4,
+		Signal: parser.Signal{
+			SumBytes:          1604,
+			SumCheckCodeSize:  4,
+			NumPoints:         50,
+			NumChannels:       16,
+			IndexAvailableChs: []int{0, 1, 2, 3, 4, 5, 6, 7},
+			IndexPntsSumCheck: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		},
 	})
 	binAdapter := adapter.NewBinAdapter(binAdConn, parser)
 

--- a/internal/adapter/bin_adapter.go
+++ b/internal/adapter/bin_adapter.go
@@ -33,7 +33,8 @@ func (a *adapter) ReceiveADValues(ctx context.Context) (*model.Signals, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to receive binary data %w", err)
 	}
-	signals, err := a.Parser.ToSignals(rawBytes)
+	signals := model.NewSignals()
+	err = a.Parser.ToSignals(rawBytes, &signals)
 	if err != nil {
 		if e, ok := err.(*parser.FailureSumCheckError); ok {
 			if err := a.sendNAK(); err != nil {
@@ -46,7 +47,7 @@ func (a *adapter) ReceiveADValues(ctx context.Context) (*model.Signals, error) {
 	if err != nil {
 		return nil, err
 	}
-	return signals, nil
+	return &signals, nil
 }
 
 func (a *adapter) sendACK() error {

--- a/internal/adapter/bin_adapter.go
+++ b/internal/adapter/bin_adapter.go
@@ -28,7 +28,7 @@ type adapter struct {
 
 // AD値を受信する
 func (a *adapter) ReceiveADValues(ctx context.Context) (*model.Signals, error) {
-	rawBytes := make([]byte, model.SumBytes)
+	rawBytes := make([]byte, model.NumTotalBytes)
 	_, err := a.Conn.Read(rawBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to receive binary data %w", err)

--- a/internal/adapter/bin_adapter_test.go
+++ b/internal/adapter/bin_adapter_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Be3751/MaP1058-socket-client/internal/model"
 	my_parser "github.com/Be3751/MaP1058-socket-client/internal/parser"
 	mock_parser "github.com/Be3751/MaP1058-socket-client/internal/parser/mock"
 	mock_socket "github.com/Be3751/MaP1058-socket-client/internal/socket/mock"
@@ -23,7 +22,7 @@ func TestReceiveADValues(t *testing.T) {
 
 		buf := make([]byte, 1604)
 		socket.EXPECT().Read(buf).Return(1604, nil)
-		parser.EXPECT().ToSignals(buf).Return(&model.Signals{}, nil)
+		parser.EXPECT().ToSignals(buf, gomock.Any()).Return(nil)
 		socket.EXPECT().Write([]byte("ACK")).Return(3, nil)
 
 		signals, err := binAdapter.ReceiveADValues(ctx)
@@ -41,10 +40,7 @@ func TestReceiveADValues(t *testing.T) {
 
 		buf := make([]byte, 1604)
 		socket.EXPECT().Read(buf).Return(1604, nil)
-		parser.EXPECT().ToSignals(buf).Return(
-			nil,
-			&my_parser.FailureSumCheckError{Expected: 100, Actual: 10},
-		)
+		parser.EXPECT().ToSignals(buf, gomock.Any()).Return(&my_parser.FailureSumCheckError{Expected: 100, Actual: 10})
 		socket.EXPECT().Write([]byte("NAK")).Return(3, nil)
 
 		signals, err := binAdapter.ReceiveADValues(ctx)

--- a/internal/model/signal.go
+++ b/internal/model/signal.go
@@ -1,28 +1,33 @@
 package model
 
+import "time"
+
 const (
 	// 1回の受信に含まれるバイト数
-	SumBytes = (numCh * numPnt * adLen) + sumCheckCodeSize
-	// チャンネル数
-	numCh = 16
-	// 実際に利用可能なチャンネル数（16種類のうち1~8のみが利用可能）
-	numAvailableCh = 8
-	// 1回の受信で1つのチャンネルが取得できる信号の数
-	numPnt = 50
-	// AD値を意味するバイト列の長さ
-	adLen = 2
+	NumTotalBytes = (NumChannels * NumPoints * NumADBytes) + SumCheckCodeSize
+	// AD値と解釈するために必要なバイト数
+	NumADBytes = 2
 	// サムチェックコードを示すバイト列の長さ
-	sumCheckCodeSize = 4
+	SumCheckCodeSize = 4
+	// チャンネル数
+	NumChannels = 16
+	// 実際に利用可能なチャンネル数（16種類のうち1~8のみが利用可能）
+	NumAvailableChs = 8
+	// 1回の受信で1つのチャンネルが取得できる信号の数
+	NumPoints = 50
+	// 先頭の何ポイントまでの値をサムチェックに用いるか
+	NumPntsSumCheck = 10
 )
 
 // 送信バイナリーデータ1回分のAD値
 type Signals struct {
-	Channels [numAvailableCh]channelSignal
+	time     time.Time
+	Channels [NumAvailableChs]channelSignal
 }
 
 type channelSignal struct {
-	ADValues     [numPnt]uint16
-	Measurements [numPnt]float64
+	ADValues     [NumPoints]uint16
+	Measurements [NumPoints]float64
 }
 
 func (s *Signals) SetMeasurements(cal *Cal) error {
@@ -38,10 +43,11 @@ func (s *Signals) SetMeasurements(cal *Cal) error {
 
 // AD値から測定値に変換するための校正値
 type Cal struct {
-	Channels [numAvailableCh]channelCal
+	Channels [NumAvailableChs]channelCal
 }
 
 type channelCal struct {
+	time   time.Time
 	BaseAD uint16
 	CalAD  uint16
 	EuHi   float64

--- a/internal/model/signal.go
+++ b/internal/model/signal.go
@@ -19,9 +19,16 @@ const (
 	NumPntsSumCheck = 10
 )
 
+func NewSignals() Signals {
+	return Signals{
+		Time:     time.Now(),
+		Channels: [NumAvailableChs]channelSignal{},
+	}
+}
+
 // 送信バイナリーデータ1回分のAD値
 type Signals struct {
-	time     time.Time
+	Time     time.Time
 	Channels [NumAvailableChs]channelSignal
 }
 
@@ -47,7 +54,6 @@ type Cal struct {
 }
 
 type channelCal struct {
-	time   time.Time
 	BaseAD uint16
 	CalAD  uint16
 	EuHi   float64

--- a/internal/parser/mock/mock_parser.go
+++ b/internal/parser/mock/mock_parser.go
@@ -35,16 +35,15 @@ func (m *MockParser) EXPECT() *MockParserMockRecorder {
 }
 
 // ToSignals mocks base method.
-func (m *MockParser) ToSignals(adSignals []byte) (*model.Signals, error) {
+func (m *MockParser) ToSignals(b []byte, s *model.Signals) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ToSignals", adSignals)
-	ret0, _ := ret[0].(*model.Signals)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "ToSignals", b, s)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // ToSignals indicates an expected call of ToSignals.
-func (mr *MockParserMockRecorder) ToSignals(adSignals interface{}) *gomock.Call {
+func (mr *MockParserMockRecorder) ToSignals(b, s interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ToSignals", reflect.TypeOf((*MockParser)(nil).ToSignals), adSignals)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ToSignals", reflect.TypeOf((*MockParser)(nil).ToSignals), b, s)
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -4,7 +4,8 @@ package parser
 import "github.com/Be3751/MaP1058-socket-client/internal/model"
 
 type Parser interface {
-	ToSignals(adSignals []byte) (*model.Signals, error)
+	// AD値のバイト列を解析してAD値を持つmodel.Signals型のポインタを返す
+	ToSignals(b []byte, s *model.Signals) error
 }
 
 func NewParser() Parser {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -7,32 +7,9 @@ type Parser interface {
 	ToSignals(adSignals []byte) (*model.Signals, error)
 }
 
-func NewParser(c ParseConfig) Parser {
-	return &parser{
-		Config: c,
-	}
+func NewParser() Parser {
+	return &parser{}
 }
 
 type parser struct {
-	// 解析に必要な設定値
-	Config ParseConfig
-}
-
-type ParseConfig struct {
-	Signal Signal
-}
-
-type Signal struct {
-	// 受信信号のバイト数
-	SumBytes uint64
-	// 受信信号に含まれるサムチェックコードのバイト数
-	SumCheckCodeSize uint64
-	// 受信信号におけるポイント数
-	NumPoints uint64
-	// 受信信号における総チャンネル数
-	NumChannels uint64
-	// 受信信号における有効チャンネルのインデックス
-	IndexAvailableChs []int
-	// サムチェックに使用するポイントのインデックス
-	IndexPntsSumCheck []int
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -19,8 +19,20 @@ type parser struct {
 }
 
 type ParseConfig struct {
-	// 1受信あたりに得られる信号のバイト数
+	Signal Signal
+}
+
+type Signal struct {
+	// 受信信号のバイト数
 	SumBytes uint64
-	// 1受信あたりに得られる信号に含まれるサムチェックコードのバイト数
+	// 受信信号に含まれるサムチェックコードのバイト数
 	SumCheckCodeSize uint64
+	// 受信信号におけるポイント数
+	NumPoints uint64
+	// 受信信号における総チャンネル数
+	NumChannels uint64
+	// 受信信号における有効チャンネルのインデックス
+	IndexAvailableChs []int
+	// サムチェックに使用するポイントのインデックス
+	IndexPntsSumCheck []int
 }

--- a/internal/parser/signal.go
+++ b/internal/parser/signal.go
@@ -9,23 +9,21 @@ import (
 	"github.com/Be3751/MaP1058-socket-client/internal/model"
 )
 
-// AD値のバイト列を解析してAD値を持つmodel.Signals型のポインタを返す
-func (p *parser) ToSignals(adSignals []byte) (*model.Signals, error) {
-	if len(adSignals) != int(model.NumTotalBytes) {
-		return nil, fmt.Errorf("adSignals' len must be %d", model.NumTotalBytes)
+func (p *parser) ToSignals(b []byte, s *model.Signals) error {
+	if len(b) != int(model.NumTotalBytes) {
+		return fmt.Errorf("the arg b's len must be %d", model.NumTotalBytes)
 	}
 
-	signalBuf := bytes.NewBuffer(adSignals[:model.NumTotalBytes-model.SumCheckCodeSize])
-	result := &model.Signals{}
+	signalBuf := bytes.NewBuffer(b[:model.NumTotalBytes-model.SumCheckCodeSize])
 	var sum uint16
 	for pnt := 0; pnt < int(model.NumPoints); pnt++ {
 		for ch := 0; ch < model.NumAvailableChs; ch++ {
 			var adValue uint16
 			err := binary.Read(signalBuf, binary.BigEndian, &adValue)
 			if err != nil {
-				return nil, fmt.Errorf("failed to read binary: %w", err)
+				return fmt.Errorf("failed to read binary: %w", err)
 			}
-			result.Channels[ch].ADValues[pnt] = adValue
+			s.Channels[ch].ADValues[pnt] = adValue
 			if pnt < model.NumPntsSumCheck {
 				sum += adValue
 			}
@@ -34,16 +32,16 @@ func (p *parser) ToSignals(adSignals []byte) (*model.Signals, error) {
 	}
 
 	var valueSumCheckCode uint32
-	sumCheckBuf := bytes.NewBuffer(adSignals[model.NumTotalBytes-model.SumCheckCodeSize:])
+	sumCheckBuf := bytes.NewBuffer(b[model.NumTotalBytes-model.SumCheckCodeSize:])
 	err := binary.Read(sumCheckBuf, binary.BigEndian, &valueSumCheckCode)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read binary: %w", err)
+		return fmt.Errorf("failed to read binary: %w", err)
 	}
 
 	if int(valueSumCheckCode) != int(sum) {
-		return nil, &FailureSumCheckError{Expected: uint16(valueSumCheckCode), Actual: sum}
+		return &FailureSumCheckError{Expected: uint16(valueSumCheckCode), Actual: sum}
 	}
-	return result, nil
+	return nil
 }
 
 type FailureSumCheckError struct {

--- a/internal/parser/signal_test.go
+++ b/internal/parser/signal_test.go
@@ -11,19 +11,9 @@ func TestToSignals(t *testing.T) {
 		sumBytes         = 1604
 		sumCheckCodeSize = 4
 	)
-	pConf := ParseConfig{
-		Signal: Signal{
-			SumBytes:          1604,
-			SumCheckCodeSize:  4,
-			NumPoints:         50,
-			NumChannels:       16,
-			IndexAvailableChs: []int{0, 1, 2, 3, 4, 5, 6, 7},
-			IndexPntsSumCheck: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-		},
-	}
 
 	t.Run("信号をパースする", func(t *testing.T) {
-		parser := NewParser(pConf)
+		parser := NewParser()
 		rawBytes := make([]byte, 1604)
 		for i := 0; i < sumBytes-sumCheckCodeSize; i += 32 {
 			for j := 0; j < 16; j++ {
@@ -41,14 +31,14 @@ func TestToSignals(t *testing.T) {
 	})
 
 	t.Run("規定の長さでないバイト列を受け取ってエラー", func(t *testing.T) {
-		parser := NewParser(pConf)
+		parser := NewParser()
 		rawBytes := []byte{0x00, 0x01, 0x02}
 		_, err := parser.ToSignals(rawBytes)
 		assert.Error(t, err)
 	})
 
 	t.Run("サムチェックの結果が合わずエラー", func(t *testing.T) {
-		parser := NewParser(pConf)
+		parser := NewParser()
 		rawBytes := make([]byte, 1604)
 		for i := 0; i < sumBytes-sumCheckCodeSize; i += 32 {
 			for j := 0; j < 16; j++ {

--- a/internal/parser/signal_test.go
+++ b/internal/parser/signal_test.go
@@ -11,14 +11,19 @@ func TestToSignals(t *testing.T) {
 		sumBytes         = 1604
 		sumCheckCodeSize = 4
 	)
+	pConf := ParseConfig{
+		Signal: Signal{
+			SumBytes:          1604,
+			SumCheckCodeSize:  4,
+			NumPoints:         50,
+			NumChannels:       16,
+			IndexAvailableChs: []int{0, 1, 2, 3, 4, 5, 6, 7},
+			IndexPntsSumCheck: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		},
+	}
 
 	t.Run("信号をパースする", func(t *testing.T) {
-		pConf := ParseConfig{
-			SumBytes:         sumBytes,
-			SumCheckCodeSize: sumCheckCodeSize,
-		}
 		parser := NewParser(pConf)
-
 		rawBytes := make([]byte, 1604)
 		for i := 0; i < sumBytes-sumCheckCodeSize; i += 32 {
 			for j := 0; j < 16; j++ {
@@ -31,16 +36,11 @@ func TestToSignals(t *testing.T) {
 		}
 		rawBytes[sumBytes-2] = 0x00
 		rawBytes[sumBytes-1] = 0x50
-
 		_, err := parser.ToSignals(rawBytes)
 		assert.NoError(t, err)
 	})
 
 	t.Run("規定の長さでないバイト列を受け取ってエラー", func(t *testing.T) {
-		pConf := ParseConfig{
-			SumBytes:         sumBytes,
-			SumCheckCodeSize: sumCheckCodeSize,
-		}
 		parser := NewParser(pConf)
 		rawBytes := []byte{0x00, 0x01, 0x02}
 		_, err := parser.ToSignals(rawBytes)
@@ -48,12 +48,7 @@ func TestToSignals(t *testing.T) {
 	})
 
 	t.Run("サムチェックの結果が合わずエラー", func(t *testing.T) {
-		pConf := ParseConfig{
-			SumBytes:         sumBytes,
-			SumCheckCodeSize: sumCheckCodeSize,
-		}
 		parser := NewParser(pConf)
-
 		rawBytes := make([]byte, 1604)
 		for i := 0; i < sumBytes-sumCheckCodeSize; i += 32 {
 			for j := 0; j < 16; j++ {
@@ -62,7 +57,6 @@ func TestToSignals(t *testing.T) {
 		}
 		rawBytes[sumBytes-2] = 0x00
 		rawBytes[sumBytes-1] = 0x50
-
 		_, err := parser.ToSignals(rawBytes)
 		assert.EqualValues(t, &FailureSumCheckError{Expected: 80, Actual: 257 * 80}, err)
 	})

--- a/internal/parser/signal_test.go
+++ b/internal/parser/signal_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"testing"
 
+	"github.com/Be3751/MaP1058-socket-client/internal/model"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,14 +27,16 @@ func TestToSignals(t *testing.T) {
 		}
 		rawBytes[sumBytes-2] = 0x00
 		rawBytes[sumBytes-1] = 0x50
-		_, err := parser.ToSignals(rawBytes)
+		signals := model.NewSignals()
+		err := parser.ToSignals(rawBytes, &signals)
 		assert.NoError(t, err)
 	})
 
 	t.Run("規定の長さでないバイト列を受け取ってエラー", func(t *testing.T) {
 		parser := NewParser()
 		rawBytes := []byte{0x00, 0x01, 0x02}
-		_, err := parser.ToSignals(rawBytes)
+		signals := model.NewSignals()
+		err := parser.ToSignals(rawBytes, &signals)
 		assert.Error(t, err)
 	})
 
@@ -47,7 +50,8 @@ func TestToSignals(t *testing.T) {
 		}
 		rawBytes[sumBytes-2] = 0x00
 		rawBytes[sumBytes-1] = 0x50
-		_, err := parser.ToSignals(rawBytes)
+		signals := model.NewSignals()
+		err := parser.ToSignals(rawBytes, &signals)
 		assert.EqualValues(t, &FailureSumCheckError{Expected: 80, Actual: 257 * 80}, err)
 	})
 }


### PR DESCRIPTION

- (*parser).ToStrings()をリファクタリング
- parseに必要な信号周りの設定値はmodelに定義