### PR TITLE
SetMeasurementsをテスト

### DIFF
--- a/internal/adapter/bin_adapter.go
+++ b/internal/adapter/bin_adapter.go
@@ -34,7 +34,7 @@ func (a *adapter) ReceiveADValues(ctx context.Context) (*model.Signals, error) {
 		return nil, fmt.Errorf("failed to receive binary data %w", err)
 	}
 	signals := model.NewSignals()
-	err = a.Parser.ToSignals(rawBytes, &signals)
+	err = a.Parser.ToSignals(rawBytes, signals)
 	if err != nil {
 		if e, ok := err.(*parser.FailureSumCheckError); ok {
 			if err := a.sendNAK(); err != nil {
@@ -47,7 +47,7 @@ func (a *adapter) ReceiveADValues(ctx context.Context) (*model.Signals, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &signals, nil
+	return signals, nil
 }
 
 func (a *adapter) sendACK() error {

--- a/internal/model/signal.go
+++ b/internal/model/signal.go
@@ -19,10 +19,9 @@ const (
 	NumPntsSumCheck = 10
 )
 
-func NewSignals() Signals {
-	return Signals{
-		Time:     time.Now(),
-		Channels: [NumAvailableChs]channelSignal{},
+func NewSignals() *Signals {
+	return &Signals{
+		Time: time.Now(),
 	}
 }
 

--- a/internal/model/signal.go
+++ b/internal/model/signal.go
@@ -1,6 +1,9 @@
 package model
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 const (
 	// 1回の受信に含まれるバイト数
@@ -36,11 +39,15 @@ type channelSignal struct {
 	Measurements [NumPoints]float64
 }
 
-func (s *Signals) SetMeasurements(cal Cal) {
+func (s *Signals) SetMeasurements(cal Cal) error {
 	for i, ch := range s.Channels {
 		for j, adV := range ch.ADValues {
 			chCal := cal[i]
-			ch.Measurements[j] = (float64(adV)-chCal.BaseAD)*(chCal.EuHi-chCal.EuLo)/chCal.CalAD + chCal.EuLo
+			if chCal.CalAD == 0 {
+				return fmt.Errorf("value of CAL_AD must not be 0. CAL_AD at %dch is 0", i+1)
+			}
+			s.Channels[i].Measurements[j] = (float64(adV)-chCal.BaseAD)*(chCal.EuHi-chCal.EuLo)/chCal.CalAD + chCal.EuLo
 		}
 	}
+	return nil
 }

--- a/internal/model/signal_test.go
+++ b/internal/model/signal_test.go
@@ -1,0 +1,64 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetMeasurements(t *testing.T) {
+	t.Run("計測値をセット", func(t *testing.T) {
+		signals := NewSignals()
+		for ch := range signals.Channels {
+			for pnt := range signals.Channels[ch].ADValues {
+				signals.Channels[ch].ADValues[pnt] = 1
+			}
+		}
+		cal := Cal{
+			{1, 1, 0, 2},
+			{1, 1, 0, 0},
+			{1, 1, 0, 0},
+			{1, 1, 0, 0},
+			{1, 1, 0, 0},
+			{1, 1, 0, 0},
+			{1, 1, 0, 0},
+			{1, 1, 0, 0},
+		}
+		err := signals.SetMeasurements(cal)
+		assert.NoError(t, err)
+		for ch := range signals.Channels {
+			for pnt := range signals.Channels[ch].Measurements {
+				if ch == 0 {
+					assert.Equal(t, float64(2), signals.Channels[ch].Measurements[pnt])
+				} else {
+					assert.Equal(t, float64(0), signals.Channels[ch].Measurements[pnt])
+				}
+			}
+		}
+	})
+
+	t.Run("CAL_ADの値が0のCalを受け取ってエラー", func(t *testing.T) {
+		signals := NewSignals()
+		cal := Cal{
+			{1, 0, 0, 2},
+			{1, 0, 0, 0},
+			{1, 0, 0, 0},
+			{1, 0, 0, 0},
+			{1, 0, 0, 0},
+			{1, 0, 0, 0},
+			{1, 0, 0, 0},
+			{1, 0, 0, 0},
+		}
+		err := signals.SetMeasurements(cal)
+		assert.Error(t, err)
+	})
+}
+
+func randomRawBytes(signalByteSize int, sumCheckCodeSize int) []byte {
+	rawBytes := make([]byte, signalByteSize)
+	for i := 0; i < signalByteSize; i++ {
+		// TODO: byte型の乱数を生成する
+		rawBytes = append(rawBytes)
+	}
+	return rawBytes
+}

--- a/internal/parser/signal_test.go
+++ b/internal/parser/signal_test.go
@@ -28,7 +28,7 @@ func TestToSignals(t *testing.T) {
 		rawBytes[sumBytes-2] = 0x00
 		rawBytes[sumBytes-1] = 0x50
 		signals := model.NewSignals()
-		err := parser.ToSignals(rawBytes, &signals)
+		err := parser.ToSignals(rawBytes, signals)
 		assert.NoError(t, err)
 	})
 
@@ -36,7 +36,7 @@ func TestToSignals(t *testing.T) {
 		parser := NewParser()
 		rawBytes := []byte{0x00, 0x01, 0x02}
 		signals := model.NewSignals()
-		err := parser.ToSignals(rawBytes, &signals)
+		err := parser.ToSignals(rawBytes, signals)
 		assert.Error(t, err)
 	})
 
@@ -51,7 +51,7 @@ func TestToSignals(t *testing.T) {
 		rawBytes[sumBytes-2] = 0x00
 		rawBytes[sumBytes-1] = 0x50
 		signals := model.NewSignals()
-		err := parser.ToSignals(rawBytes, &signals)
+		err := parser.ToSignals(rawBytes, signals)
 		assert.EqualValues(t, &FailureSumCheckError{Expected: 80, Actual: 257 * 80}, err)
 	})
 }


### PR DESCRIPTION
- `NewSignals()`がポインタ型で返すように変更
- `SetMeasurements()`が0除算になる前にerrorを返すように変更
- `SetMeasurements()`をテスト