### PR TITLE
AD値の受信処理を改修

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -69,6 +69,10 @@ func main() {
 		}
 	}()
 
+	// TODO: RANGE値を取得
+	// TODO: ANALYSIS値を取得
+	// TODO: CAL値を取得
+
 	// 10 x 50 ポイントのAD値を受信する
 	for i := 0; i < 10; i++ {
 		s, err := binAdapter.ReceiveADValues(ctx)
@@ -76,6 +80,9 @@ func main() {
 			panic(err)
 		}
 		fmt.Println(s)
+		// TODO: CAL値を取得するまで待機
+		// TODO: 取得したCAL値から計測値を算出
+		// TODO: 計測値をファイルに書き込む
 	}
 
 }

--- a/internal/adapter/bin_adapter.go
+++ b/internal/adapter/bin_adapter.go
@@ -56,7 +56,7 @@ func (a *binAdapter) ReceiveADValues(ctx context.Context) (*model.Signals, error
 }
 
 func (a *binAdapter) sendACK() error {
-	_, err := a.Conn.Write([]byte("ACK"))
+	_, err := a.Conn.Write([]byte{0x06})
 	if err != nil {
 		return fmt.Errorf("failed to write connection ACK: %w", err)
 	}
@@ -64,7 +64,7 @@ func (a *binAdapter) sendACK() error {
 }
 
 func (a *binAdapter) sendNAK() error {
-	_, err := a.Conn.Write([]byte("NAK"))
+	_, err := a.Conn.Write([]byte{0x15})
 	if err != nil {
 		return fmt.Errorf("failed to write connection NAK: %w", err)
 	}

--- a/internal/adapter/bin_adapter_test.go
+++ b/internal/adapter/bin_adapter_test.go
@@ -23,7 +23,7 @@ func TestReceiveADValues(t *testing.T) {
 		buf := make([]byte, 1604)
 		socket.EXPECT().Read(buf).Return(1604, nil)
 		parser.EXPECT().ToSignals(buf, gomock.Any()).Return(nil)
-		socket.EXPECT().Write([]byte("ACK")).Return(3, nil)
+		socket.EXPECT().Write([]byte{0x06}).Return(1, nil)
 
 		signals, err := binAdapter.ReceiveADValues(ctx)
 		assert.NoError(t, err)
@@ -41,7 +41,7 @@ func TestReceiveADValues(t *testing.T) {
 		buf := make([]byte, 1604)
 		socket.EXPECT().Read(buf).Return(1604, nil)
 		parser.EXPECT().ToSignals(buf, gomock.Any()).Return(&my_parser.FailureSumCheckError{Expected: 100, Actual: 10})
-		socket.EXPECT().Write([]byte("NAK")).Return(3, nil)
+		socket.EXPECT().Write([]byte{0x15}).Return(1, nil)
 
 		signals, err := binAdapter.ReceiveADValues(ctx)
 		assert.Error(t, err)

--- a/internal/adapter/txt_adapter.go
+++ b/internal/adapter/txt_adapter.go
@@ -71,7 +71,7 @@ func (a *txtAdapter) EndRec(ctx context.Context) error {
 	}
 	rCmdStr := string(buf[:readLen])
 	if string(rCmdStr) != sCmdStr {
-		return fmt.Errorf("failed to end recording")
+		return fmt.Errorf("the received cmd `%s` dosen't match with the sent one `%s`", rCmdStr, sCmdStr)
 	}
 	return nil
 }

--- a/internal/model/signal.go
+++ b/internal/model/signal.go
@@ -7,11 +7,13 @@ import (
 
 const (
 	// 1回の受信に含まれるバイト数
-	NumTotalBytes = (NumChannels * NumPoints * NumADBytes) + SumCheckCodeSize
+	NumTotalBytes = 1604
 	// AD値と解釈するために必要なバイト数
 	NumADBytes = 2
 	// サムチェックコードを示すバイト列の長さ
 	SumCheckCodeSize = 4
+	// サムチェックコードを示すバイト列のうち下位2ビットのみ有効
+	SumCheckCodeAvailableSize = 2
 	// チャンネル数
 	NumChannels = 16
 	// 実際に利用可能なチャンネル数（16種類のうち1~8のみが利用可能）

--- a/internal/parser/mock/mock_parser.go
+++ b/internal/parser/mock/mock_parser.go
@@ -50,15 +50,16 @@ func (mr *MockParserMockRecorder) ToCommand(s interface{}) *gomock.Call {
 }
 
 // ToSignals mocks base method.
-func (m *MockParser) ToSignals(b []byte, s *model.Signals) error {
+func (m *MockParser) ToSignals(b []byte) (*model.Signals, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ToSignals", b, s)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "ToSignals", b)
+	ret0, _ := ret[0].(*model.Signals)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // ToSignals indicates an expected call of ToSignals.
-func (mr *MockParserMockRecorder) ToSignals(b, s interface{}) *gomock.Call {
+func (mr *MockParserMockRecorder) ToSignals(b interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ToSignals", reflect.TypeOf((*MockParser)(nil).ToSignals), b, s)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ToSignals", reflect.TypeOf((*MockParser)(nil).ToSignals), b)
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -5,7 +5,7 @@ import "github.com/Be3751/MaP1058-socket-client/internal/model"
 
 type Parser interface {
 	// AD値のバイト列を解析してAD値を持つmodel.Signals型のポインタを返す
-	ToSignals(b []byte, s *model.Signals) error
+	ToSignals(b []byte) (*model.Signals, error)
 	ToCommand(s string) (*model.Command, error)
 }
 


### PR DESCRIPTION
実装内容は以下の通り。

**ネットワーク周り**
- クライアント側のIPアドレスを取得する関数を追加
- サーバーのIPアドレス、クライアントのポート番号を修正

**ロジック周り**
- サムチェックの処理を修正
- ACKとNAKのコードを修正
- 上記の修正に伴うテストコードの修正