### PR TITLE
並行受信を実装

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -82,7 +82,7 @@ func main() {
 	// TODO: 設定値をファイルに書き込む
 
 	go func() {
-		err := binAdapter.WriteADValues(ctx, os.Stdout)
+		err := binAdapter.WriteRawSignal(ctx, os.Stdout)
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -64,12 +64,12 @@ func main() {
 	binAdapter := adapter.NewBinAdapter(binAdConn, parser)
 	csvWriterGroup := adapter.CSVWriterGroup{}
 
-	err = txtAdapter.StartRec(ctx, time.Second*60, time.Now())
+	err = txtAdapter.StartRec(time.Second*60, time.Now())
 	if err != nil {
 		panic(err)
 	}
 	defer func() {
-		err = txtAdapter.EndRec(ctx)
+		err = txtAdapter.EndRec()
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/Be3751/MaP1058-socket-client/internal/adapter"
@@ -56,11 +57,12 @@ func main() {
 		}
 	}()
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 	parser := parser.NewParser()
 	scanner := scanner.NewCustomScanner(txtAdConn)
 	txtAdapter := adapter.NewTxtAdapter(txtAdConn, scanner, parser)
 	binAdapter := adapter.NewBinAdapter(binAdConn, parser)
+	csvWriterGroup := adapter.CSVWriterGroup{}
 
 	err = txtAdapter.StartRec(ctx, time.Second*60, time.Now())
 	if err != nil {
@@ -71,7 +73,6 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		os.Exit(0)
 	}()
 
 	setting, err := txtAdapter.GetSetting()
@@ -80,25 +81,22 @@ func main() {
 	}
 	// TODO: 設定値をファイルに書き込む
 
-	// TODO: 生波形の受信と解析データの受信を並行して行う
-	// TODO: ENDコマンドを受信するまで、生波形の受信とファイル書き込みを繰り返す
-	for i := 0; i < 10; i++ {
-		s, err := binAdapter.ReceiveADValues(ctx)
+	go func() {
+		err := binAdapter.WriteADValues(ctx, os.Stdout)
 		if err != nil {
 			panic(err)
 		}
-		err = s.SetMeasurements(setting.Calibration)
+	}()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := txtAdapter.WriteTrendData(ctx, csvWriterGroup, setting.AnalysisType)
 		if err != nil {
 			panic(err)
 		}
-		fmt.Println(s)
-		// // TODO: 計測値をファイルに書き込む
-		// _, err = file.WriteString()
-		// if err != nil {
-		// 	panic(err)
-		// }
-	}
-
-	// TODO: ENDコマンドを受信するまで、解析データの受信とファイル書き込みを繰り返す
-	// TODO: 計測値をファイルに書き込む
+	}()
+	// ENDコマンドを送信するまで待機（ENDコマンドを送信する処理が別途必要）
+	wg.Wait()
+	cancel()
 }

--- a/internal/adapter/bin_adapter.go
+++ b/internal/adapter/bin_adapter.go
@@ -4,16 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/Be3751/MaP1058-socket-client/internal/model"
 	"github.com/Be3751/MaP1058-socket-client/internal/parser"
 	"github.com/Be3751/MaP1058-socket-client/internal/socket"
 )
 
-// バイナリーデータで生波形データのAD値を受信する
 type BinAdapter interface {
-	// AD値を受信する
-	ReceiveADValues(ctx context.Context) (*model.Signals, error)
+	// WriteADValues AD値を受信する
+	WriteADValues(ctx context.Context, w io.Writer) error
 }
 
 func NewBinAdapter(c socket.Conn, p parser.Parser) BinAdapter {
@@ -28,32 +28,45 @@ type binAdapter struct {
 	Parser parser.Parser
 }
 
-func (a *binAdapter) ReceiveADValues(ctx context.Context) (*model.Signals, error) {
-	rawBytes := make([]byte, model.NumTotalBytes)
+func (a *binAdapter) WriteADValues(ctx context.Context, w io.Writer) error {
 	for {
-		n, err := a.Conn.Read(rawBytes)
-		if err != nil {
-			return nil, fmt.Errorf("failed to receive binary data: %w", err)
-		}
-		if n == 0 {
-			return nil, errors.New("received 0 byte")
-		}
-
-		s, err := a.Parser.ToSignals(rawBytes)
-		if err == nil {
-			if err := a.sendACK(); err != nil {
-				return nil, err
+		select {
+		case <-ctx.Done():
+			return nil
+			// TODO: ここで生波形データをファイルに書き込む
+		default:
+			_, err := a.receiveAD()
+			if err != nil {
+				return fmt.Errorf("failed to receive AD values: %w", err)
 			}
-			return s, nil
-		} else if _, ok := err.(*parser.FailureSumCheckError); ok {
-			if err := a.sendNAK(); err != nil {
-				return nil, fmt.Errorf("%s, and failed to send NAK to the server", err.Error())
-			}
-		} else {
-			return nil, fmt.Errorf("failed to parse binary data to Signals: %w", err)
 		}
-		rawBytes = make([]byte, model.NumTotalBytes)
 	}
+}
+
+func (a *binAdapter) receiveAD() (*model.Signals, error) {
+	rawBytes := make([]byte, model.NumTotalBytes)
+	n, err := a.Conn.Read(rawBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to receive binary data: %w", err)
+	}
+	if n == 0 {
+		return nil, errors.New("received 0 byte")
+	}
+
+	s, err := a.Parser.ToSignals(rawBytes[:n])
+	if err == nil {
+		if err := a.sendACK(); err != nil {
+			return nil, err
+		}
+		return s, nil
+	} else if _, ok := err.(*parser.FailureSumCheckError); ok {
+		if err := a.sendNAK(); err != nil {
+			return nil, fmt.Errorf("%s, and failed to send NAK to the server", err.Error())
+		}
+	} else {
+		return nil, fmt.Errorf("failed to parse binary data to Signals: %w", err)
+	}
+	return s, nil
 }
 
 func (a *binAdapter) sendACK() error {

--- a/internal/adapter/bin_adapter.go
+++ b/internal/adapter/bin_adapter.go
@@ -12,8 +12,8 @@ import (
 )
 
 type BinAdapter interface {
-	// WriteADValues AD値を受信する
-	WriteADValues(ctx context.Context, w io.Writer) error
+	// WriteRawSignal AD値を受信する
+	WriteRawSignal(ctx context.Context, w io.Writer) error
 }
 
 func NewBinAdapter(c socket.Conn, p parser.Parser) BinAdapter {
@@ -28,7 +28,7 @@ type binAdapter struct {
 	Parser parser.Parser
 }
 
-func (a *binAdapter) WriteADValues(ctx context.Context, w io.Writer) error {
+func (a *binAdapter) WriteRawSignal(ctx context.Context, w io.Writer) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/adapter/bin_adapter_test.go
+++ b/internal/adapter/bin_adapter_test.go
@@ -29,7 +29,7 @@ func TestReceiveADValues(t *testing.T) {
 			return 1, nil
 		})
 
-		err := binAdapter.WriteADValues(ctx, nil)
+		err := binAdapter.WriteRawSignal(ctx, nil)
 		assert.NoError(t, err)
 	})
 
@@ -52,7 +52,7 @@ func TestReceiveADValues(t *testing.T) {
 			return 1, nil
 		})
 
-		err := binAdapter.WriteADValues(ctx, nil)
+		err := binAdapter.WriteRawSignal(ctx, nil)
 		assert.NoError(t, err)
 	})
 }

--- a/internal/adapter/txt_adapter.go
+++ b/internal/adapter/txt_adapter.go
@@ -18,9 +18,9 @@ import (
 
 // TxtAdapter テキストデータでトレンドデータの受信やコマンドの送受信をする
 type TxtAdapter interface {
-	StartRec(ctx context.Context, recTime time.Duration, recDateTime time.Time) error
-	EndRec(ctx context.Context) error
-	GetStatus(ctx context.Context) (model.Status, error)
+	StartRec(recTime time.Duration, recDateTime time.Time) error
+	EndRec() error
+	GetStatus() (model.Status, error)
 	WriteTrendData(ctx context.Context, w CSVWriterGroup, at model.AnalysisType) error
 	GetSetting() (*model.Setting, error)
 }
@@ -39,7 +39,7 @@ type txtAdapter struct {
 	Parser  parser.Parser
 }
 
-func (a *txtAdapter) StartRec(ctx context.Context, recSecond time.Duration, recDateTime time.Time) error {
+func (a *txtAdapter) StartRec(recSecond time.Duration, recDateTime time.Time) error {
 	recDateTimeParam := recDateTime.Format("2006/01/02 15-04-05")
 	recSecondParam := strSecond(recSecond)
 	sCmd := model.Command{
@@ -63,7 +63,7 @@ func (a *txtAdapter) StartRec(ctx context.Context, recSecond time.Duration, recD
 	return nil
 }
 
-func (a *txtAdapter) EndRec(ctx context.Context) error {
+func (a *txtAdapter) EndRec() error {
 	sCmd := model.Command{
 		Name: "END",
 	}
@@ -84,7 +84,7 @@ func (a *txtAdapter) EndRec(ctx context.Context) error {
 	return nil
 }
 
-func (a *txtAdapter) GetStatus(ctx context.Context) (model.Status, error) {
+func (a *txtAdapter) GetStatus() (model.Status, error) {
 	sCmd := model.Command{
 		Name: "STATUS",
 	}

--- a/internal/adapter/txt_adapter_test.go
+++ b/internal/adapter/txt_adapter_test.go
@@ -1,7 +1,6 @@
 package adapter
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -30,10 +29,9 @@ func TestStartRec(t *testing.T) {
 			},
 		)
 		conn.EXPECT().Read(gomock.Any()).SetArg(0, []byte(sCmdStr)).Return(len(sCmdStr), nil)
-		ctx := context.Background()
 
 		txtAdapter := NewTxtAdapter(conn, scanner, parser)
-		err := txtAdapter.StartRec(ctx, time.Second*300, time.Date(2023, 1, 1, 12, 0, 0, 0, time.Local))
+		err := txtAdapter.StartRec(time.Second*300, time.Date(2023, 1, 1, 12, 0, 0, 0, time.Local))
 		assert.NoError(t, err)
 	})
 }
@@ -54,10 +52,9 @@ func TestEndRec(t *testing.T) {
 			},
 		)
 		conn.EXPECT().Read(gomock.Any()).SetArg(0, []byte(sCmdStr)).Return(len(sCmdStr), nil)
-		ctx := context.Background()
 
 		txtAdapter := NewTxtAdapter(conn, scanner, parser)
-		err := txtAdapter.EndRec(ctx)
+		err := txtAdapter.EndRec()
 		assert.NoError(t, err)
 	})
 }
@@ -79,11 +76,10 @@ func TestGetStatus(t *testing.T) {
 		)
 		rCmd := []byte("<SCMD>STATUS:A:Acq,,,,,,,,,</SCMD>")
 		conn.EXPECT().Read(gomock.Any()).SetArg(0, rCmd).Return(len(rCmd), nil)
-		ctx := context.Background()
 		parser.EXPECT().ToCommand(string(rCmd)).Return(model.Command{Name: "STATUS", Params: [10]string{"Acq"}}, nil)
 
 		txtAdapter := NewTxtAdapter(conn, scanner, parser)
-		status, err := txtAdapter.GetStatus(ctx)
+		status, err := txtAdapter.GetStatus()
 		assert.NoError(t, err)
 		assert.Equal(t, "Acq", string(status))
 	})


### PR DESCRIPTION
生波形の受信と解析値の受信を並行して実行するように実装した。

**主な実装内容**
- 生波形の受信をする関数と解析値の受信をする関数を並行処理に対応
- WaitGroupを使うことで、ENDコマンドを受信するまでは信号の受信と書き込みを継続し、mainのgoroutineを待機
- WriteRawSignalは自身で受信の終了を検知する仕組みがないため、mainのgoroutineからのcontextのcancelにより通知

**その他**
- 不要なcontext.Contextを引数に持つシグネチャを修正
- 生波形を受信する関数の名前を変更