### PR TITLE
go.mod記載のmodule名を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 
 # saved data
 output/*
+
+.DS_Store

--- a/client.go
+++ b/client.go
@@ -4,16 +4,16 @@ import (
 	"context"
 	"encoding/csv"
 	"fmt"
-	"github.com/Be3751/MaP1058-socket-client/internal/model"
-	"github.com/Be3751/MaP1058-socket-client/internal/utils/net"
+	"github.com/ISDL-dev/MaP1058-socket-client/internal/model"
+	"github.com/ISDL-dev/MaP1058-socket-client/internal/utils/net"
 	"os"
 	"sync"
 	"time"
 
-	"github.com/Be3751/MaP1058-socket-client/internal/adapter"
-	"github.com/Be3751/MaP1058-socket-client/internal/parser"
-	"github.com/Be3751/MaP1058-socket-client/internal/scanner"
-	"github.com/Be3751/MaP1058-socket-client/internal/socket"
+	"github.com/ISDL-dev/MaP1058-socket-client/internal/adapter"
+	"github.com/ISDL-dev/MaP1058-socket-client/internal/parser"
+	"github.com/ISDL-dev/MaP1058-socket-client/internal/scanner"
+	"github.com/ISDL-dev/MaP1058-socket-client/internal/socket"
 )
 
 type Client interface {

--- a/cmd/exapmle/main.go
+++ b/cmd/exapmle/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	client "github.com/Be3751/MaP1058-socket-client"
+	client "github.com/ISDL-dev/MaP1058-socket-client"
 	"time"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Be3751/MaP1058-socket-client
+module github.com/ISDL-dev/MaP1058-socket-client
 
 go 1.18
 

--- a/internal/adapter/bin_adapter.go
+++ b/internal/adapter/bin_adapter.go
@@ -5,9 +5,9 @@ import (
 	"encoding/csv"
 	"errors"
 	"fmt"
-	"github.com/Be3751/MaP1058-socket-client/internal/model"
-	"github.com/Be3751/MaP1058-socket-client/internal/parser"
-	"github.com/Be3751/MaP1058-socket-client/internal/socket"
+	"github.com/ISDL-dev/MaP1058-socket-client/internal/model"
+	"github.com/ISDL-dev/MaP1058-socket-client/internal/parser"
+	"github.com/ISDL-dev/MaP1058-socket-client/internal/socket"
 	"io"
 	"time"
 )

--- a/internal/adapter/bin_adapter_test.go
+++ b/internal/adapter/bin_adapter_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Be3751/MaP1058-socket-client/internal/model"
-	my_parser "github.com/Be3751/MaP1058-socket-client/internal/parser"
-	mock_parser "github.com/Be3751/MaP1058-socket-client/internal/parser/mock"
-	mock_socket "github.com/Be3751/MaP1058-socket-client/internal/socket/mock"
+	"github.com/ISDL-dev/MaP1058-socket-client/internal/model"
+	my_parser "github.com/ISDL-dev/MaP1058-socket-client/internal/parser"
+	mock_parser "github.com/ISDL-dev/MaP1058-socket-client/internal/parser/mock"
+	mock_socket "github.com/ISDL-dev/MaP1058-socket-client/internal/socket/mock"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )

--- a/internal/adapter/mock/mock_bin_adapter.go
+++ b/internal/adapter/mock/mock_bin_adapter.go
@@ -8,7 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	model "github.com/Be3751/MaP1058-socket-client/internal/model"
+	model "github.com/ISDL-dev/MaP1058-socket-client/internal/model"
 	gomock "go.uber.org/mock/gomock"
 )
 

--- a/internal/adapter/txt_adapter.go
+++ b/internal/adapter/txt_adapter.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Be3751/MaP1058-socket-client/internal/model"
-	"github.com/Be3751/MaP1058-socket-client/internal/parser"
-	"github.com/Be3751/MaP1058-socket-client/internal/scanner"
-	"github.com/Be3751/MaP1058-socket-client/internal/socket"
+	"github.com/ISDL-dev/MaP1058-socket-client/internal/model"
+	"github.com/ISDL-dev/MaP1058-socket-client/internal/parser"
+	"github.com/ISDL-dev/MaP1058-socket-client/internal/scanner"
+	"github.com/ISDL-dev/MaP1058-socket-client/internal/socket"
 )
 
 // TxtAdapter テキストデータでトレンドデータの受信やコマンドの送受信をする

--- a/internal/adapter/txt_adapter_test.go
+++ b/internal/adapter/txt_adapter_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Be3751/MaP1058-socket-client/internal/model"
-	mock_parser "github.com/Be3751/MaP1058-socket-client/internal/parser/mock"
-	mock_scanner "github.com/Be3751/MaP1058-socket-client/internal/scanner/mock"
-	mock_socket "github.com/Be3751/MaP1058-socket-client/internal/socket/mock"
+	"github.com/ISDL-dev/MaP1058-socket-client/internal/model"
+	mock_parser "github.com/ISDL-dev/MaP1058-socket-client/internal/parser/mock"
+	mock_scanner "github.com/ISDL-dev/MaP1058-socket-client/internal/scanner/mock"
+	mock_socket "github.com/ISDL-dev/MaP1058-socket-client/internal/socket/mock"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )

--- a/internal/parser/command.go
+++ b/internal/parser/command.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/Be3751/MaP1058-socket-client/internal/model"
+	"github.com/ISDL-dev/MaP1058-socket-client/internal/model"
 )
 
 func (p *parser) ToCommand(s string) (model.Command, error) {

--- a/internal/parser/command_test.go
+++ b/internal/parser/command_test.go
@@ -2,7 +2,7 @@ package parser
 
 import (
 	"fmt"
-	"github.com/Be3751/MaP1058-socket-client/internal/model"
+	"github.com/ISDL-dev/MaP1058-socket-client/internal/model"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/internal/parser/mock/mock_parser.go
+++ b/internal/parser/mock/mock_parser.go
@@ -7,7 +7,7 @@ package mock_parser
 import (
 	reflect "reflect"
 
-	model "github.com/Be3751/MaP1058-socket-client/internal/model"
+	model "github.com/ISDL-dev/MaP1058-socket-client/internal/model"
 	gomock "go.uber.org/mock/gomock"
 )
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,7 +1,7 @@
-//go:generate mockgen -source=$GOFILE -destination=mock/mock_$GOFILE -package=mock_$GOPACKAGE -self_package=github.com/Be3751/MaP1058-socket-client/$GOPACKAGE
+//go:generate mockgen -source=$GOFILE -destination=mock/mock_$GOFILE -package=mock_$GOPACKAGE -self_package=github.com/ISDL-dev/MaP1058-socket-client/$GOPACKAGE
 package parser
 
-import "github.com/Be3751/MaP1058-socket-client/internal/model"
+import "github.com/ISDL-dev/MaP1058-socket-client/internal/model"
 
 type Parser interface {
 	// AD値のバイト列を解析してAD値を持つmodel.Signals型のポインタを返す

--- a/internal/parser/signal.go
+++ b/internal/parser/signal.go
@@ -1,4 +1,4 @@
-//go:generate mockgen -source=$GOFILE -destination=mock/mock_$GOFILE -package=mock_$GOPACKAGE -self_package=github.com/Be3751/MaP1058-socket-client/$GOPACKAGE
+//go:generate mockgen -source=$GOFILE -destination=mock/mock_$GOFILE -package=mock_$GOPACKAGE -self_package=github.com/ISDL-dev/MaP1058-socket-client/$GOPACKAGE
 package parser
 
 import (
@@ -6,7 +6,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/Be3751/MaP1058-socket-client/internal/model"
+	"github.com/ISDL-dev/MaP1058-socket-client/internal/model"
 )
 
 func (p *parser) ToSignals(b []byte) (*model.Signals, error) {

--- a/internal/parser/signal_test.go
+++ b/internal/parser/signal_test.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"testing"
 
-	"github.com/Be3751/MaP1058-socket-client/internal/model"
+	"github.com/ISDL-dev/MaP1058-socket-client/internal/model"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,4 +1,4 @@
-//go:generate mockgen -source=$GOFILE -destination=mock/mock_$GOFILE -package=mock_$GOPACKAGE -self_package=github.com/Be3751/MaP1058-socket-client/$GOPACKAGE
+//go:generate mockgen -source=$GOFILE -destination=mock/mock_$GOFILE -package=mock_$GOPACKAGE -self_package=github.com/ISDL-dev/MaP1058-socket-client/$GOPACKAGE
 package scanner
 
 import (

--- a/internal/socket/client.go
+++ b/internal/socket/client.go
@@ -1,4 +1,4 @@
-//go:generate mockgen -source=$GOFILE -destination=mock/mock_$GOFILE -package=mock_$GOPACKAGE -self_package=github.com/Be3751/MaP1058-socket-client/$GOPACKAGE
+//go:generate mockgen -source=$GOFILE -destination=mock/mock_$GOFILE -package=mock_$GOPACKAGE -self_package=github.com/ISDL-dev/MaP1058-socket-client/$GOPACKAGE
 package socket
 
 import (

--- a/internal/socket/test_client/main.go
+++ b/internal/socket/test_client/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/Be3751/MaP1058-socket-client/internal/socket"
+	"github.com/ISDL-dev/MaP1058-socket-client/internal/socket"
 )
 
 func main() {

--- a/internal/socket/test_server/main.go
+++ b/internal/socket/test_server/main.go
@@ -3,7 +3,7 @@ package main
 
 import (
 	"fmt"
-	utilsNet "github.com/Be3751/MaP1058-socket-client/internal/utils/net"
+	utilsNet "github.com/ISDL-dev/MaP1058-socket-client/internal/utils/net"
 	"net"
 	"os"
 	"time"


### PR DESCRIPTION
## 内容
### 目的
GitHub transportする前のリポジトリ名になっていたため、正しいリポジトリ名に修正する。

### 変更内容
go.modに記載されているmodule名を修正

### 注意事項
一度mainに取り込まないと、`go get github.com/ISDL-dev/MaP1058-socket-client`が出来ないと思われるため、PRをmergeした後にmainでimportに問題があれば追加のfixブランチを切る予定。

### 関連したIssue
なし